### PR TITLE
Fix Translation of Phetchabun / Phetchaburi

### DIFF
--- a/covidthailand.py
+++ b/covidthailand.py
@@ -1130,7 +1130,7 @@ def get_provinces():
     provinces.loc['อดุรธานี'] = provinces.loc['Udon Thani']
     provinces.loc['พระนครศรอียธุยา'] = provinces.loc['Ayutthaya']
     provinces.loc['สระบรุ'] = provinces.loc['Saraburi']
-    provinces.loc['เพชรบรุ'] = provinces.loc['Phetchabun']
+    provinces.loc['เพชรบรุ'] = provinces.loc['Phetchaburi']
     provinces.loc['ราชบรุ'] = provinces.loc['Ratchaburi']
     provinces.loc['เชยีงราย'] = provinces.loc['Chiang Rai']
     provinces.loc['อบุลราชธานี'] = provinces.loc['Ubon Ratchathani']


### PR DESCRIPTION
Notice the vowel differences. 
On `Line:1133` in `def get_provinces()`, this line attempts to match to Phetchabun province based on a partial name. The key difference between Phetchabun and Phetchaburi is the vowel is in long or short form. 
`Line:1133` is the short form, and should therefore map to Phetchaburi.

I'll attach some images to the pull request to help verify this.

![image](https://user-images.githubusercontent.com/3637403/119253636-56e54f80-bbdc-11eb-9482-5d89524ba02c.png)
![image](https://user-images.githubusercontent.com/3637403/119253678-8a27de80-bbdc-11eb-973f-99f41b00b30b.png)


![image](https://user-images.githubusercontent.com/3637403/119253644-65336b80-bbdc-11eb-84ad-a9c72f188f7b.png)
![image](https://user-images.githubusercontent.com/3637403/119253663-75e3e180-bbdc-11eb-8f5b-cb20a411a334.png)

