### PR TITLE
add json files to test three commits that touched briefing_case_types

### DIFF
--- a/tests/briefing_case_types/2021-05-17.json
+++ b/tests/briefing_case_types/2021-05-17.json
@@ -1,0 +1,84 @@
+{
+    "schema":{
+      "fields":[
+        {
+          "name":"Date",
+          "type":"datetime"
+        },
+        {
+          "name":"Cases",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Walkin",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Proactive",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Imported",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Area Prison",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Hospital",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Field",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Severe",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Respirator",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized",
+          "type":"integer"
+        },
+        {
+          "name":"Recovered",
+          "type":"integer"
+        },
+        {
+          "name":"Deaths",
+          "type":"integer"
+        },
+        {
+          "name":"Source Cases",
+          "type":"string"
+        }
+      ],
+      "primaryKey":[
+        "Date"
+      ],
+      "pandas_version":"0.20.0"
+    },
+    "data":[
+      {
+        "Date":"2021-05-17T00:00:00.000Z",
+        "Cases":9635,
+        "Cases Walkin":1820,
+        "Cases Proactive":953,
+        "Cases Imported":9,
+        "Cases Area Prison":6853,
+        "Hospitalized Hospital":22662,
+        "Hospitalized Field":20606,
+        "Hospitalized Severe":1226,
+        "Hospitalized Respirator":400,
+        "Hospitalized":43268,
+        "Recovered":1397,
+        "Deaths":25,
+        "Source Cases":"briefings\/170564.pdf"
+      }
+    ]
+  }

--- a/tests/briefing_case_types/2021-06-25.json
+++ b/tests/briefing_case_types/2021-06-25.json
@@ -1,0 +1,84 @@
+{
+    "schema":{
+      "fields":[
+        {
+          "name":"Date",
+          "type":"datetime"
+        },
+        {
+          "name":"Cases",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Walkin",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Proactive",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Imported",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Area Prison",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Hospital",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Field",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Severe",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Respirator",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized",
+          "type":"integer"
+        },
+        {
+          "name":"Recovered",
+          "type":"integer"
+        },
+        {
+          "name":"Deaths",
+          "type":"integer"
+        },
+        {
+          "name":"Source Cases",
+          "type":"string"
+        }
+      ],
+      "primaryKey":[
+        "Date"
+      ],
+      "pandas_version":"0.20.0"
+    },
+    "data":[
+      {
+        "Date":"2021-06-25T00:00:00.000Z",
+        "Cases":3644,
+        "Cases Walkin":2803,
+        "Cases Proactive":648,
+        "Cases Imported":31,
+        "Cases Area Prison":162,
+        "Hospitalized Hospital":14702,
+        "Hospitalized Field":26664,
+        "Hospitalized Severe":1603,
+        "Hospitalized Respirator":460,
+        "Hospitalized":41366,
+        "Recovered":1751,
+        "Deaths":44,
+        "Source Cases":"briefings\/250664.pdf"
+      }
+    ]
+  }

--- a/tests/briefing_case_types/2021-08-13.json
+++ b/tests/briefing_case_types/2021-08-13.json
@@ -1,0 +1,84 @@
+{
+    "schema":{
+      "fields":[
+        {
+          "name":"Date",
+          "type":"datetime"
+        },
+        {
+          "name":"Cases",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Walkin",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Proactive",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Imported",
+          "type":"integer"
+        },
+        {
+          "name":"Cases Area Prison",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Hospital",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Field",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Severe",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized Respirator",
+          "type":"integer"
+        },
+        {
+          "name":"Hospitalized",
+          "type":"integer"
+        },
+        {
+          "name":"Recovered",
+          "type":"integer"
+        },
+        {
+          "name":"Deaths",
+          "type":"integer"
+        },
+        {
+          "name":"Source Cases",
+          "type":"string"
+        }
+      ],
+      "primaryKey":[
+        "Date"
+      ],
+      "pandas_version":"0.20.0"
+    },
+    "data":[
+      {
+        "Date":"2021-08-13T00:00:00.000Z",
+        "Cases":23418,
+        "Cases Walkin":17642,
+        "Cases Proactive":5379,
+        "Cases Imported":9,
+        "Cases Area Prison":388,
+        "Hospitalized Hospital":61299,
+        "Hospitalized Field":150880,
+        "Hospitalized Severe":5565,
+        "Hospitalized Respirator":1111,
+        "Hospitalized":212179,
+        "Recovered":20083,
+        "Deaths":184,
+        "Source Cases":"briefings\/130864.pdf"
+      }
+    ]
+  }

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -211,6 +211,17 @@ def test_briefing_deaths_summary(date, testdf, dl):
 
 @pytest.mark.parametrize("date, testdf, dl", dl_files("briefing_case_types", briefing_documents))
 def test_briefing_case_types(date, testdf, dl):
+    """
+    The following json files check code that was added by corresponding commits.
+
+    tests/briefing_case_types/{2021-05-17,\
+                               2021-06-25,\
+                               2021-08-13}.json
+
+    2021-05-17 8998d907: fix parsing briefings
+    2021-06-25 5d054122: parse vac in briefing
+    2021-08-13 74aa7877: fix parse briefing cases
+    """
     assert dl is not None
     file = dl()
     assert file is not None


### PR DESCRIPTION
This data causes the test function to generate 99% coverage for the function under test (the missing 1% is the empty data pre 2021-02-01 whose line of code I don't think fits into this test harness). I suspect, however, that having coverage for every line of code is not the same as having coverage that proves every change in the data source is being handled correctly. I'm not used to testing changes in data sources rather than code itself... Please show me an example of a commit you think still needs test data for and hopefully I'll gain a better understanding of what further dates I should be adding test data for; thanks! :smile: