### PR TITLE
fix: update broken download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thailand COVID-19 case/test/vaccination data gathered and combined from various 
 
 - Updated daily 8-9am summary info, 1-3pm from full briefing. Testing data is updated every 1-3 weeks. [![last update was](https://github.com/djay/covidthailand/actions/workflows/main.yml/badge.svg)](https://github.com/djay/covidthailand/actions/workflows/main.yml).
 
-## [Cases](#cases) |  [Deaths](#deaths) | [Vaccinations](#vaccinations) | [Active Cases](#active-cases) | [Testing](#testing) | [Downloads](downloads) | [About](#about)
+## [Cases](#cases) |  [Deaths](#deaths) | [Vaccinations](#vaccinations) | [Active Cases](#active-cases) | [Testing](#testing) | [Downloads](downloads.md) | [About](#about)
 
 **NEW** [Excess Deaths](#excess-deaths)
 
@@ -16,7 +16,7 @@ Thailand COVID-19 case/test/vaccination data gathered and combined from various 
 and data feeds have been used effort has gone into making this data collection accurate and timely.
 This sites only intention is to give an accurate representation of all the available Covid data for Thailand in one place.*
 
-Links to all data sources are including in [Downloads](downloads)
+Links to all data sources are including in [Downloads](downloads.md)
 
 
 # Trends


### PR DESCRIPTION
Current download link redirects to 404:
![image](https://user-images.githubusercontent.com/22489525/144557513-8ed489a1-bb2e-415c-823f-67590367402f.png)
