### PR TITLE
Fix Y2K-Thai bug (64 -> 65)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
           echo "::set-output name=year::$(TZ=Asia/Bangkok date +'%Y')"
           echo "::set-output name=hour::$(TZ=Asia/Bangkok date +'%H')"
           echo "::set-output name=time::$(TZ=Asia/Bangkok date +'%H:%M')"
-          echo "::set-output name=briefingurl::http://media.thaigov.go.th/uploads/public_img/source/$(TZ=Asia/Bangkok date +'%d%m')64.pdf"
-          echo "::set-output name=briefingfile::inputs/briefings/$(TZ=Asia/Bangkok date +'%d%m')64.pdf"
+          echo "::set-output name=briefingurl::http://media.thaigov.go.th/uploads/public_img/source/$(TZ=Asia/Bangkok date +'%d%m')$(($(TZ=Asia/Bangkok date +'%Y')-1957)).pdf"
+          echo "::set-output name=briefingfile::inputs/briefings/$(TZ=Asia/Bangkok date +'%d%m')$(($(TZ=Asia/Bangkok date +'%Y')-1957)).pdf"
       - name: Check briefing doc available
         id: briefing
         continue-on-error: true


### PR DESCRIPTION
### Fix Thai year in briefings report download URL within main.yml workflow. 
i.e. For 2021 returns 64. For 2022 returns 65, etc.  This replaces the hardcoded year.

```
$(($(TZ=Asia/Bangkok date +'%Y')-1957))
# i.e. convert 2022 to Int, then subtract..
```

- [x] Tested in GNU Bash 4.3.x / Linux
- [ ] Need to verify in Github Workflow.