### PR TITLE
try using proxies to vac reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
-          sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy &
       - name: is dash ready
         id: godash
         if: ${{ steps.dep.outcome == 'success' && steps.dep.dash != 'success' && github.event_name	== 'schedule'}}
@@ -174,6 +173,7 @@ jobs:
       - name: Run tests
         if:  ${{ github.event_name	!= 'schedule'}}
         run: |
+          sudo docker run -t -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
           pytest
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades
@@ -182,6 +182,7 @@ jobs:
         id: updateapi
         if: ${{ steps.gofull.outcome != 'success' && steps.godash.outcome != 'success' && steps.goapi.outcome == 'success' }}
         run: |
+            sudo docker run -t -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
             python covid_data_api.py
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,9 @@ jobs:
         run: python -c "import covid_data_dash; covid_data_dash.check_dash_ready()"
       - name: Run tests
         if:  ${{ github.event_name	!= 'schedule'}}
-        run: pytest
+        run: |
+          sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
+          pytest
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades
            DRIVE_API_KEY: ${{ secrets.DRIVE_API_KEY }}
@@ -180,6 +182,7 @@ jobs:
         id: updateapi
         if: ${{ steps.gofull.outcome != 'success' && steps.godash.outcome != 'success' && steps.goapi.outcome == 'success' }}
         run: |
+            sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
             python covid_data_api.py
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,7 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install wheel
           pip install -r requirements.txt
+          sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy &
       - name: is dash ready
         id: godash
         if: ${{ steps.dep.outcome == 'success' && steps.dep.dash != 'success' && github.event_name	== 'schedule'}}
@@ -173,7 +174,6 @@ jobs:
       - name: Run tests
         if:  ${{ github.event_name	!= 'schedule'}}
         run: |
-          sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
           pytest
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades
@@ -182,7 +182,6 @@ jobs:
         id: updateapi
         if: ${{ steps.gofull.outcome != 'success' && steps.godash.outcome != 'success' && steps.goapi.outcome == 'success' }}
         run: |
-            sudo docker run -it -p 8118:8118 -p 9050:9050 -l "TH" -d dperson/torproxy
             python covid_data_api.py
         env:
            TIKA_VERSION: 1.24 # Prevent delays in upgrades

--- a/covid_data_testing.py
+++ b/covid_data_testing.py
@@ -55,6 +55,9 @@ def get_drive_files(folder_id, ext="pdf", dir="inputs/testing_moph"):
         token = res['nextPageToken']
         url = f"https://www.googleapis.com/drive/v3/files?q=%27{folder_id}%27+in+parents&key={key}&pageToken={token}"
         res = requests.get(url).json()
+        if "files" not in res:
+            logger.error(str(res))
+            break
         files.extend(res["files"])
 
     count = 0

--- a/covid_data_vac.py
+++ b/covid_data_vac.py
@@ -625,20 +625,21 @@ def vaccination_reports_files2(check=True,
                                base1="https://ddc.moph.go.th/dcd/pagecontent.php?page=643&dept=dcd",
                                base2="https://ddc.moph.go.th/vaccine-covid19/diaryReportMonth/{m:02}/9/2021",
                                ext=".pdf",
+                               timeout=20,
                                ):
     # https://ddc.moph.go.th/vaccine-covid19/diaryReport
     # or https://ddc.moph.go.th/dcd/pagecontent.php?page=643&dept=dcd
 
     # more reliable from dec 2021 and updated quicker
     hasyear = re.compile("(2564|2565)")
-    years = web_links(base1, ext=None, match=hasyear, check=1, proxy=True)
-    months = (link for link in web_links(*years, ext=None, match=hasyear, check=1, proxy=True))
-    links1 = (link for link in web_links(*months, ext=".pdf", check=1, proxy=True) if (
+    years = web_links(base1, ext=None, match=hasyear, check=1, proxy=True, timeout=timeout)
+    months = (link for link in web_links(*years, ext=None, match=hasyear, check=1, proxy=True, timeout=timeout))
+    links1 = (link for link in web_links(*months, ext=".pdf", check=1, proxy=True, timeout=timeout) if (
         date := file2date(link)) is not None and date >= d("2021-12-01") or (any_in(link.lower(), *['wk', "week"])))
 
     # this set was more reliable for awhile. Need to match tests
     folders = [base2.format(m=m) for m in range(11, 2, -1)]
-    links2 = (link for f in folders for link in reversed(list(web_links(f, ext=ext, check=False, proxy=True))))
+    links2 = (link for f in folders for link in reversed(list(web_links(f, ext=ext, check=False, proxy=True, timeout=timeout))))
     links = list(links1) + list(links2)
     count = 0
     for link in links:
@@ -648,7 +649,7 @@ def vaccination_reports_files2(check=True,
 
         def get_file(link=link):
             try:
-                file, _, _ = next(iter(web_files(link, dir="inputs/vaccinations", proxy=True)))
+                file, _, _ = next(iter(web_files(link, dir="inputs/vaccinations", proxy=True, timeout=timeout)))
             except StopIteration:
                 return None
             return file

--- a/covid_data_vac.py
+++ b/covid_data_vac.py
@@ -631,14 +631,14 @@ def vaccination_reports_files2(check=True,
 
     # more reliable from dec 2021 and updated quicker
     hasyear = re.compile("(2564|2565)")
-    years = web_links(base1, ext=None, match=hasyear, check=1, timeout=20)
-    months = (link for link in web_links(*years, ext=None, match=hasyear, check=1, timeout=20))
-    links1 = (link for link in web_links(*months, ext=".pdf", check=1, timeout=20) if (
+    years = web_links(base1, ext=None, match=hasyear, check=1, proxy=True)
+    months = (link for link in web_links(*years, ext=None, match=hasyear, check=1, proxy=True))
+    links1 = (link for link in web_links(*months, ext=".pdf", check=1, proxy=True) if (
         date := file2date(link)) is not None and date >= d("2021-12-01") or (any_in(link.lower(), *['wk', "week"])))
 
     # this set was more reliable for awhile. Need to match tests
     folders = [base2.format(m=m) for m in range(11, 2, -1)]
-    links2 = (link for f in folders for link in reversed(list(web_links(f, ext=ext, check=False, timeout=20))))
+    links2 = (link for f in folders for link in reversed(list(web_links(f, ext=ext, check=False, proxy=True))))
     links = list(links1) + list(links2)
     count = 0
     for link in links:

--- a/covid_data_vac.py
+++ b/covid_data_vac.py
@@ -648,7 +648,7 @@ def vaccination_reports_files2(check=True,
 
         def get_file(link=link):
             try:
-                file, _, _ = next(iter(web_files(link, dir="inputs/vaccinations")))
+                file, _, _ = next(iter(web_files(link, dir="inputs/vaccinations", proxy=True)))
             except StopIteration:
                 return None
             return file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests[socks]
 tabula-py
 tika
 webdavclient3
@@ -8,7 +8,7 @@ python-pptx
 python-dateutil
 # jupyter
 wheel
-pytwitterscraper
+# pytwitterscraper
 camelot-py[cv,plot] == 0.8.2
 pandas > 1.4.0  # < 1.3.0 # div bt zero?
 numpy
@@ -28,3 +28,4 @@ python-crfsuite
 benford_py
 tqdm
 pre-commit-hooks
+proxyscrape

--- a/utils_scraping.py
+++ b/utils_scraping.py
@@ -351,7 +351,7 @@ def web_links(*index_urls, ext=".pdf", dir="inputs/html", match=None, filenamer=
     def is_match(a):
         return a.get("href") and is_ext(a) and (match.search(a.get_text(strip=True)) if match else True)
 
-    for file, index, index_url in web_files(*index_urls, dir=dir, check=check, filenamer=filenamer, timeout=5, proxy=proxy):
+    for file, index, index_url in web_files(*index_urls, dir=dir, check=check, filenamer=filenamer, timeout=timeout, proxy=proxy):
         soup = parse_file(file, html=True, paged=False)
         links = (urllib.parse.urljoin(index_url, a.get('href')) for a in soup.find_all('a') if is_match(a))
         for link in links:
@@ -363,6 +363,7 @@ def web_files(*urls, dir=os.getcwd(), check=CHECK_NEWER, strip_version=False, ap
     s = requests.Session()
     fix_timeouts(s, timeout)
     i = 0
+    proxies = next(proxies_itor, None) if proxy else None
     for url in urls:
         file = filenamer(url, strip_version)
         file = os.path.join(dir, file)
@@ -374,7 +375,7 @@ def web_files(*urls, dir=os.getcwd(), check=CHECK_NEWER, strip_version=False, ap
 
         if check or MAX_DAYS:
             try:
-                r = s.head(url, timeout=timeout, verify=verify, proxies=next(proxies_itor) if proxy else None)
+                r = s.head(url, timeout=timeout, verify=verify, proxies=proxies)
                 modified = r.headers.get("Last-Modified")
                 if r.headers.get("content-range"):
                     pre, size = r.headers.get("content-range").split("/")
@@ -400,7 +401,7 @@ def web_files(*urls, dir=os.getcwd(), check=CHECK_NEWER, strip_version=False, ap
                 # handle resuming based on range requests - https://stackoverflow.com/questions/22894211/how-to-resume-file-download-in-python
                 # Speed up covid-19 download a lot, but might have to jump back to make sure we don't miss data.
                 r = s.get(url, timeout=timeout, stream=True, headers=resume_header, allow_redirects=True,
-                          verify=verify, proxies=next(proxies_itor) if proxy else None)
+                          verify=verify, proxies=proxies)
             except (Timeout, ConnectionError) as e:
                 err = str(e)
                 r = None
@@ -720,7 +721,7 @@ def get_proxy():
     def to_proxies(d):
         if "http" in [p["type"] for p in d['protocols']]:
             return {
-                p["type"]: f"{p['type']}://{d['ip']}:{p['port']}" for p in d['protocols']
+                p["type"]: f"http://{d['ip']}:{p['port']}" for p in d['protocols']
             }
         else:
             p = d['protocols'][0]
@@ -740,7 +741,7 @@ def get_proxy():
                 return proxies
         except requests.exceptions.RequestException:
             pass
-        logger.info(f"Failed Test proxy {proxies}")
+        # logger.info(f"Failed Test proxy {proxies}")
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=15) as executor:
         for future in concurrent.futures.as_completed(executor.submit(test_proxy, p) for p in proxies):

--- a/utils_scraping.py
+++ b/utils_scraping.py
@@ -711,6 +711,11 @@ def read_excel(path: str, sheet_name: str = None) -> pd.DataFrame:
 
 
 def get_proxy():
+    while True:
+        yield {
+            "http": "socks4://127.0.0.1:9050",
+            "https": "socks4://127.0.0.1:9050"
+        }
     url = "https://raw.githubusercontent.com/mertguvencli/http-proxy-list/main/proxy-list/data-with-geolocation.json"
     url = "https://raw.githubusercontent.com/jetkai/proxy-list/main/online-proxies/json/proxies-advanced.json"
     data = requests.get(url).json()


### PR DESCRIPTION
Problem is that ddc website is now geo locked so any outside request is blocked. Luckily this only seems to effect the vac reports and not other sources.

Attempts to fix
- [x] free http proxies
    - wrote the code to get and test them. can't seem to find source thats reliable enough
- [x] tor
   - works using docker but there are no exitnodes in thailand due to laws so not usable
- [ ] free openvpn
   - seems possible - https://www.freeopenvpn.org/private.php?cntid=Thailand&lang=en but do we need use multiple and test them?
- [x] paid vpn
   - I have surfshark but has no exit in thailand
- [ ] are they cached somewhere else? google?
- [ ] other ideas?